### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/hotimglibrary/src/main/java/com/dreamlive/hotimglibrary/utils/FileUtils.java
+++ b/hotimglibrary/src/main/java/com/dreamlive/hotimglibrary/utils/FileUtils.java
@@ -7,7 +7,11 @@ import java.io.InputStream;
  * 文件操作帮助类
  * Created by dreamlivemeng on 2016/6/7.
  */
-public class FileUtils {
+public final class FileUtils {
+
+    private FileUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     /**
      * 关闭输入流

--- a/hotimglibrary/src/main/java/com/dreamlive/hotimglibrary/utils/LogUtils.java
+++ b/hotimglibrary/src/main/java/com/dreamlive/hotimglibrary/utils/LogUtils.java
@@ -7,10 +7,14 @@ import android.util.Log;
  * 日志打印帮助类
  * Created by dreamlivemeng on 2016/6/7.
  */
-public class LogUtils {
+public final class LogUtils {
 	
 	private final static boolean IS_DEBUG = true;
-	
+
+	private LogUtils() throws InstantiationException {
+		throw new InstantiationException("This utility class is not created for instantiation");
+	}
+
 	public static void e(String tag, String msg) {
 		if(IS_DEBUG) {
 			Log.e(tag, checkMsg(msg));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
