### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/hotimglibrary/src/main/java/com/dreamlive/hotimglibrary/view/HotClickView.java
+++ b/hotimglibrary/src/main/java/com/dreamlive/hotimglibrary/view/HotClickView.java
@@ -241,6 +241,8 @@ public class HotClickView extends View {
             case MotionEvent.ACTION_CANCEL:
                 upToCheckOutOfSide(event);
                 break;
+            default:
+                break;
         }
     }
 
@@ -254,6 +256,8 @@ public class HotClickView extends View {
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
                 upToCheckIsClick(event);
+                break;
+            default:
                 break;
         }
     }
@@ -280,6 +284,8 @@ public class HotClickView extends View {
             case MotionEvent.ACTION_CANCEL:
             case MotionEvent.ACTION_UP:
                 mIsTwoFinger = false;
+                break;
+            default:
                 break;
         }
     }
@@ -506,6 +512,8 @@ public class HotClickView extends View {
                 if (event.getPointerCount() == 0) {
                     upToCheckOutOfSide(event);
                 }
+                break;
+            default:
                 break;
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat
